### PR TITLE
Upgrade to OCaml 5.2

### DIFF
--- a/B0.ml
+++ b/B0.ml
@@ -69,7 +69,7 @@ let default =
          "--dev-pkg" "%{dev}%"
          "--lib-dir" "%{lib}%"]]|}
     |> add B0_opam.depends
-      [ "ocaml", {|>= "4.08.0"|};
+      [ "ocaml", {|>= "5.2.0"|};
         "ocamlfind", {|build|};
         "ocamlbuild", {|build|};
         "topkg", {|build & >= "1.0.3"|};

--- a/opam
+++ b/opam
@@ -17,7 +17,7 @@ homepage: "https://erratique.ch/software/omod"
 doc: "https://erratique.ch/software/omod/doc/"
 bug-reports: "https://github.com/dbuenzli/omod/issues"
 depends: [
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "5.2.0"}
   "ocamlfind" {build}
   "ocamlbuild" {build}
   "topkg" {build & >= "1.0.3"}

--- a/src/omod.ml
+++ b/src/omod.ml
@@ -29,17 +29,6 @@ module String = struct
     in
     loop [] s
 
-  let starts_with ~prefix s = (* once 4.13 is requird this can be removed. *)
-    let len_a = length prefix in
-    let len_s = length s in
-    if len_a > len_s then false else
-    let max_idx_a = len_a - 1 in
-    let rec loop i =
-      if i > max_idx_a then true else
-      if unsafe_get prefix i <> unsafe_get s i then false else loop (i + 1)
-    in
-    loop 0
-
   (* Suggesting *)
 
   let edit_distance s0 s1 =

--- a/src/omod.mli
+++ b/src/omod.mli
@@ -109,10 +109,6 @@ module Private : sig
 
     val rev_cuts : sep:char -> string -> string list
 
-    val starts_with : prefix:string -> string -> bool
-    (** [starts_with ~prefix s] is [true] iff [prefix] is a prefix
-        of [s]. {b Note.} Available in 4.13. *)
-
     val edit_distance : string -> string -> int
     (** [edit_distance s0 s1] is the number of single character edits
         (insertion, deletion, substitution) that are needed to change

--- a/src/omod_ocamlc.ml
+++ b/src/omod_ocamlc.ml
@@ -141,7 +141,7 @@ module Cmo = struct
   type t = dobj
 
   let of_compilation_unit cu =
-    let name = cu.Cmo_format.cu_name in
+    let Cmo_format.Compunit name = cu.Cmo_format.cu_name in
     let iface_digest, iface_deps = split_dep name cu.Cmo_format.cu_imports in
     { name; iface_digest; iface_deps }
 


### PR DESCRIPTION
OCaml 5.2 changed the type of `Cmo_format.cu_name`.
Being unfamiliar with your build-system I'm not sure how to keep support for OCaml < 5.2 so I here propose a simple upgrade to OCaml 5.2 instead.

This may be not what you want so feel free to take this work and do whatever you want with it.
However if you are going to keep compatibility please notify me so that I can learn how you do this in your projects, so that next time I have the same issue i can do a better job.